### PR TITLE
Function convert argument "outputfile"  usage

### DIFF
--- a/Examples/MAX78000/CameraIF/pc_utility/imgConverter.py
+++ b/Examples/MAX78000/CameraIF/pc_utility/imgConverter.py
@@ -210,7 +210,7 @@ def convert(bytesequence, outputfile, xres, yres, pixelformat):
 
 	print("Output image to file xres {}, yres {}".format(xres,yres), flush=True)
 
-	g_pil_image = generate_img("image-out.png", (0, 0, 0), (xres, yres))
+	g_pil_image = generate_img(outputfile, (0, 0, 0), (xres, yres))
 	x = 0
 	y = 0
 	for i in range(int(len(imagepixels) / 3)):
@@ -224,6 +224,6 @@ def convert(bytesequence, outputfile, xres, yres, pixelformat):
 			y = y + 1
 			if y > (yres - 1):
 				break
-	g_pil_image.save("image-out.png")
+	g_pil_image.save(outputfile)
 
 


### PR DESCRIPTION
The outputfile argument of the function convert was not used within the function.
This meant if you change the file name within grab_image.py,  the change is not reflected in the output file.