### PR TITLE
initialize DMA_FLAG = 1 in the CSI example

### DIFF
--- a/Examples/MAX78002/CSI2/main.c
+++ b/Examples/MAX78002/CSI2/main.c
@@ -115,7 +115,7 @@
 
 /***** Globals *****/
 
-volatile int DMA_FLAG;
+volatile int DMA_FLAG = 1;
 
 // RAW Line Buffers
 uint32_t RAW_ADDR0[IMAGE_WIDTH] __attribute__((aligned(4)))


### PR DESCRIPTION
DMA_FLAG is uninitialized and therefore then MXC_CSI2_Stop() is called too early and the first memory transfer is empty